### PR TITLE
Avoid object mutation in config example

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ var menuConfig = {
 }
 
 function createMenu(config) {
-  Object.assign(config, {
+  config = Object.assign({}, config, {
     title: 'Foo',
     body: 'Bar',
     buttonText: 'Baz',


### PR DESCRIPTION
When using Object.assign(obj1, obj2) obj1 will be mutated and also returned by the function. To prevent that, pass an empty object literal as the first param and work with the returned value.