### PR TITLE
Add getArea method where it is necessary.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1203,6 +1203,10 @@ class Square extends Shape {
   setLength(length) {
     this.length = length;
   }
+  
+  getArea() {
+    return this.length * this.length;
+  }
 }
 
 function renderLargeShapes(shapes) {


### PR DESCRIPTION
Without this, the `shape.getArea()` call below will cause an error.