### PR TITLE
Fix default values overwriting data passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,12 +484,12 @@ var menuConfig = {
 }
 
 function createMenu(config) {
-  Object.assign(config, {
+  Object.assign({
     title: 'Foo',
     body: 'Bar',
     buttonText: 'Baz',
     cancellable: true
-  });
+  }, config);
 }
 
 createMenu(menuConfig);

--- a/README.md
+++ b/README.md
@@ -477,23 +477,35 @@ createMenu(menuConfig);
 **Good**:
 ```javascript
 var menuConfig = {
-  title: null,
-  body: 'Bar',
-  buttonText: null
-  cancellable: true
+  title: "Welcome to the year 2017",
+  body: 'Hello and welcome to the year 2017. What a year this whole 2016 was, right?',
+  cancellable: false
 }
 
 function createMenu(config) {
-  Object.assign({
-    title: 'Foo',
-    body: 'Bar',
-    buttonText: 'Baz',
+  config = Object.assign({
+    title: 'Untitled element',
+    body: 'Please provide element description.',
+    buttonText: 'See more',
     cancellable: true
   }, config);
+  
+  /**
+  * The config object will now look like this:
+  * {
+  * title: "Welcome to the year 2017",
+  * body: 'Hello and welcome to the year 2017. What a year this whole 2016 was, right?',
+  * buttonText: 'See more',
+  * cancellable: false
+  * }
+  */
 }
 
 createMenu(menuConfig);
 ```
+
+The example above will create a local scoped copy of `config` (thus preventing mutation of the original object) and all the missing fields will be populated by default values.
+
 **[⬆ back to top](#table-of-contents)**
 
 

--- a/README.md
+++ b/README.md
@@ -490,7 +490,7 @@ function createMenu(config) {
   }, config);
   
   /**
-  * The config object will now look like this:
+  * After calling the function with `menuConfig` as the parameter, the config object will be:
   * {
   * title: "Welcome to the year 2017",
   * body: 'Hello and welcome to the year 2017. What a year this whole 2016 was, right?',


### PR DESCRIPTION
In the "Set default objects with Object.assign" section your example would overwrite the data passed as a parameter with the default values. Changing the parameter order fixes the issue.

Also, the original version was mutating the passed object, but this is non-issue now.

Thanks to https://www.reddit.com/user/notNullOrVoid for spotting the mixed order.