### PR TITLE
Don't mutate the config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,7 +484,7 @@ var menuConfig = {
 }
 
 function createMenu(config) {
-  Object.assign(config, {
+  Object.assign({}, config, {
     title: 'Foo',
     body: 'Bar',
     buttonText: 'Baz',


### PR DESCRIPTION
`Object.assign` mutates the first object. This can lead to unexpected side-effects.