### PR TITLE
Moves order of Object.assign when using defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -484,12 +484,12 @@ var menuConfig = {
 }
 
 function createMenu(config) {
-  Object.assign(config, {
+  Object.assign({
     title: 'Foo',
     body: 'Bar',
     buttonText: 'Baz',
     cancellable: true
-  });
+  }, config);
 }
 
 createMenu(menuConfig);


### PR DESCRIPTION
The object full of defaults should come first since Object.assign will replace values in the first object with overridden values in the second.