### PR TITLE
Remove redundant object from Object.assign example

### DIFF
--- a/README.md
+++ b/README.md
@@ -483,7 +483,7 @@ var menuConfig = {
 }
 
 function createMenu(config) {
-  config = Object.assign({}, {
+  config = Object.assign({
     title: 'Foo',
     body: 'Bar',
     buttonText: 'Baz',


### PR DESCRIPTION
In the "good" `Object.assign` example, the initial new object is redundant as the defaults are also specified in a new object.

This is a bit pedantic, and doesn't change the semantics of the example, just removes an unnecessary object creation.

*Note:* I definitely wouldn't have bothered with this if I didn't make #4, and was looking at it anyway 😄 