### PR TITLE
Rephrase default value advice

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ function createMicrobrewery(name) {
 }
 ```
 
-**Better:**
+**Bad:**
 ```javascript
 function createMicrobrewery(name) {
   const breweryName = name || 'Hipster Brew Co.';
@@ -212,7 +212,7 @@ function createMicrobrewery(name) {
 
 ```
 
-**Best**:
+**Good**:
 ```javascript
 function createMicrobrewery(breweryName = 'Hipster Brew Co.') {
   ...

--- a/README.md
+++ b/README.md
@@ -188,25 +188,36 @@ function paintCar(car) {
 ```
 **[⬆ back to top](#table-of-contents)**
 
-### Short-circuiting is cleaner than conditionals
+### Use default arguments instead of short circuiting or conditionals
 
 **Bad:**
 ```javascript
 function createMicrobrewery(name) {
-  var breweryName;
+  let breweryName;
   if (name) {
     breweryName = name;
   } else {
     breweryName = 'Hipster Brew Co.';
   }
+  ...
 }
 ```
 
-**Good**:
+**Better:**
 ```javascript
 function createMicrobrewery(name) {
-  var breweryName = name || 'Hipster Brew Co.'
+  const breweryName = name || 'Hipster Brew Co.';
+  ...
 }
+
+```
+
+**Best**:
+```javascript
+function createMicrobrewery(breweryName = 'Hipster Brew Co.') {
+  ...
+}
+
 ```
 **[⬆ back to top](#table-of-contents)**
 
@@ -447,25 +458,6 @@ function showList(employees) {
     render(data);
   });
 }
-```
-**[⬆ back to top](#table-of-contents)**
-
-### Use default arguments instead of short circuiting
-**Bad:**
-```javascript
-function writeForumComment(subject, body) {
-  subject = subject || 'No Subject';
-  body = body || 'No text';
-}
-
-```
-
-**Good**:
-```javascript
-function writeForumComment(subject = 'No subject', body = 'No text') {
-  ...
-}
-
 ```
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -176,19 +176,6 @@ function paintCar(car) {
 **Bad:**
 ```javascript
 function createMicrobrewery(name) {
-  let breweryName;
-  if (name) {
-    breweryName = name;
-  } else {
-    breweryName = 'Hipster Brew Co.';
-  }
-  ...
-}
-```
-
-**Bad:**
-```javascript
-function createMicrobrewery(name) {
   const breweryName = name || 'Hipster Brew Co.';
   ...
 }


### PR DESCRIPTION
- The original document asserted that "Short-circuiting is cleaner than conditionals"
- ...only to override this assertion later with "Use default arguments instead of short circuiting."
- This is a poor design-choice for an advisory document.

    - If you are going to say x > y,
    - then later say z > x,
    - you should just say z > x > y upfront.
    - Otherwise, many people might not see the z > x later on,
    - because many people will probably use this as a referential document. They probably won't read the entire work.