### PR TITLE
Use destructuring for explanatory variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,9 +119,7 @@ saveCityState(cityStateRegex.match(cityStateRegex)[1], cityStateRegex.match(city
 **Good**:
 ```javascript
 const cityStateRegex = /^(.+)[,\\s]+(.+?)\s*(\d{5})?$/;
-const match = cityStateRegex.match(cityStateRegex)
-const city = match[1];
-const state = match[2];
+const [, city, state] = cityStateRegex.match(cityStateRegex);
 saveCityState(city, state);
 ```
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -112,14 +112,16 @@ for (var i = 0; i < MINUTES_IN_A_YEAR; i++) {
 ### Use explanatory variables
 **Bad:**
 ```javascript
-const cityStateRegex = /^(.+)[,\\s]+(.+?)\s*(\d{5})?$/;
-saveCityState(cityStateRegex.match(cityStateRegex)[1], cityStateRegex.match(cityStateRegex)[2]);
+const address = 'One Infinite Loop, Cupertino 95014';
+const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+saveCityState(address.match(cityStateRegex)[1], address.match(cityStateRegex)[2]);
 ```
 
 **Good**:
 ```javascript
-const cityStateRegex = /^(.+)[,\\s]+(.+?)\s*(\d{5})?$/;
-const [, city, state] = cityStateRegex.match(cityStateRegex);
+const address = 'One Infinite Loop, Cupertino 95014';
+const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+const [, city, state] = address.match(cityStateRegex);
 saveCityState(city, state);
 ```
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
This use the ES2015 way.

I removed the match because it's not used and we could also declare a const all to grab the first item of the match if needed.