### PR TITLE
Add website 🌟

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
   <meta http-equiv="X-UA-Compatible" content="IE=edge" />
   <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
   <title>Clean Code concepts adapted for JavaScript</title>
-  <link rel="stylesheet" href="https://unpkg.com/docute@1.12.2/dist/docute.css">
+  <link rel="stylesheet" href="https://unpkg.com/docute@latest/dist/docute.css">
 </head>
 <body>
   <!-- don't remove this part start -->
@@ -17,7 +17,7 @@
       twitter: 'ryconoclast'
     }
   </script>
-  <script src="https://unpkg.com/docute@1.12.2/dist/docute.js"></script>
+  <script src="https://unpkg.com/docute@latest/dist/docute.js"></script>
   <!-- livereload script placeholder -->
   <!-- don't remove this part end -->
 </body>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=0" />
+  <title>Clean Code concepts adapted for JavaScript</title>
+  <link rel="stylesheet" href="https://unpkg.com/docute@1.12.2/dist/docute.css">
+</head>
+<body>
+  <!-- don't remove this part start -->
+  <div id="app"></div>
+  <script>
+    self.$config = {
+      home: 'https://raw.githubusercontent.com/ryanmcdermott/clean-code-javascript/master/README.md',
+      repo: 'ryanmcdermott/clean-code-javascript',
+      twitter: 'ryconoclast'
+    }
+  </script>
+  <script src="https://unpkg.com/docute@1.12.2/dist/docute.js"></script>
+  <!-- livereload script placeholder -->
+  <!-- don't remove this part end -->
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -12,6 +12,8 @@
   <div id="app"></div>
   <script>
     self.$config = {
+      // title is too long, hide it on mobile devices
+      disableHeaderTitle: true,
       home: 'https://raw.githubusercontent.com/ryanmcdermott/clean-code-javascript/master/README.md',
       repo: 'ryanmcdermott/clean-code-javascript',
       twitter: 'ryconoclast'


### PR DESCRIPTION
Hi, I love this guide so much, but I find a long README is really hard to browse (the `back to top` and `table of content` are pretty nice though)

Basically this is to introduce using [docute](https://github.com/egoist/docute) to serve README.md as a website, you don't need to build or change anything, it also generates a TOC in the sidebar so that we can quickly navigate between sections.   

You can just go to the settings and choose `docs` as github pages:

![settings](https://docute.js.org/assets/deploy.png)

Hopefully we can visit the guide via https://ryanmcdermott.github.io/clean-code-javascript then, here's the preview (or try [visit my fork](https://egoistian.com/clean-code-javascript)):

![2017-01-09 11 53 57](https://cloud.githubusercontent.com/assets/8784712/21772855/e46270e4-d6c7-11e6-91ba-6b3c8addd573.png)

**Feel free to close this if it's not what you want :D cheers**