### PR TITLE
add `break` statement to prevent erroneous fall-through

### DIFF
--- a/README.md
+++ b/README.md
@@ -1213,6 +1213,7 @@ function renderLargeShapes(shapes) {
     switch (shape.constructor.name) {
       case 'Square':
         shape.setLength(5);
+        break;
       case 'Rectangle':
         shape.setWidth(4);
         shape.setHeight(5);


### PR DESCRIPTION
(Here comes a bunch of PRs after a code fragments mass test with ESLint checks and Node.js runnings.)
