### PR TITLE
Fix one code exsample use `console.log` to print error

### DIFF
--- a/README.md
+++ b/README.md
@@ -1769,7 +1769,7 @@ async function getCleanCodeArticle() {
     await fileHandle.writeFile('article.html', response);
     console.log('File written');
   } catch(err) {
-    console.log(err);
+    console.error(err);
   }
 }
 ```


### PR DESCRIPTION
Based on the **Error Handling** section.
I think good example should all use `console.error` to deal with error messages.