### PR TITLE
Remove round brackets in arrow function with one input

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Explicit is better than implicit.
 **Bad:**
 ```javascript
 const locations = ['Austin', 'New York', 'San Francisco'];
-locations.forEach((l) => {
+locations.forEach(l => {
   doStuff();
   doSomeOtherStuff();
   // ...
@@ -132,7 +132,7 @@ locations.forEach((l) => {
 **Good**:
 ```javascript
 const locations = ['Austin', 'New York', 'San Francisco'];
-locations.forEach((location) => {
+locations.forEach(location => {
   doStuff();
   doSomeOtherStuff();
   // ...


### PR DESCRIPTION
By removing the round brackets on arrow functions with one input we can improve readability.