### PR TITLE
Fix Typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ setTimeout(() => {
 **Good**:
 ```javascript
 // Declare them as capitalized `const` globals.
-const SECONDS_IN_DAY = 86400;
+const SECONDS_IN_A_DAY = 86400;
 
 setTimeout(() => {
   this.blastOff()


### PR DESCRIPTION
`SECONDS_IN_A_DAY` there was a typo in const.