### PR TITLE
fix new instances of previously fixed cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ can help identify unnamed constants.
 ```javascript
 // What the heck is 86400 for?
 setTimeout(() => {
-  this.blastOff()
+  this.blastOff();
 }, 86400);
 
 ```
@@ -92,7 +92,7 @@ setTimeout(() => {
 const SECONDS_IN_A_DAY = 86400;
 
 setTimeout(() => {
-  this.blastOff()
+  this.blastOff();
 }, SECONDS_IN_A_DAY);
 
 ```
@@ -183,7 +183,7 @@ function paintCar(car) {
 ```javascript
 function createMicrobrewery(name) {
   const breweryName = name || 'Hipster Brew Co.';
-  ...
+  // ...
 }
 
 ```
@@ -191,7 +191,7 @@ function createMicrobrewery(name) {
 **Good**:
 ```javascript
 function createMicrobrewery(breweryName = 'Hipster Brew Co.') {
-  ...
+  // ...
 }
 
 ```
@@ -382,9 +382,9 @@ function showDeveloperList(developers) {
     const experience = developer.getExperience();
     const githubLink = developer.getGithubLink();
     const data = {
-      expectedSalary: expectedSalary,
-      experience: experience,
-      githubLink: githubLink
+      expectedSalary,
+      experience,
+      githubLink
     };
 
     render(data);
@@ -397,9 +397,9 @@ function showManagerList(managers) {
     const experience = manager.getExperience();
     const portfolio = manager.getMBAProjects();
     const data = {
-      expectedSalary: expectedSalary,
-      experience: experience,
-      portfolio: portfolio
+      expectedSalary,
+      experience,
+      portfolio
     };
 
     render(data);
@@ -421,9 +421,9 @@ function showList(employees) {
     }
 
     const data = {
-      expectedSalary: expectedSalary,
-      experience: experience,
-      portfolio: portfolio
+      expectedSalary,
+      experience,
+      portfolio
     };
 
     render(data);
@@ -448,7 +448,6 @@ function createMenu(config) {
   config.body = config.body || 'Bar';
   config.buttonText = config.buttonText || 'Baz';
   config.cancellable = config.cancellable === undefined ? config.cancellable : true;
-
 }
 
 createMenu(menuConfig);
@@ -585,10 +584,6 @@ Array.prototype.diff = function diff(comparisonArray) {
 **Good:**
 ```javascript
 class SuperArray extends Array {
-  constructor(...args) {
-    super(...args);
-  }
-
   diff(comparisonArray) {
     const values = [];
     const hash = {};
@@ -1124,10 +1119,6 @@ class Rectangle {
 }
 
 class Square extends Rectangle {
-  constructor() {
-    super();
-  }
-
   setWidth(width) {
     this.width = width;
     this.height = width;
@@ -1155,8 +1146,6 @@ renderLargeRectangles(rectangles);
 **Good**:
 ```javascript
 class Shape {
-  constructor() {}
-
   setColor(color) {
     // ...
   }
@@ -1607,7 +1596,6 @@ class Employee {
   constructor(name, email) {
     this.name = name;
     this.email = email;
-
   }
 
   setTaxData(ssn, salary) {


### PR DESCRIPTION
Add missed semicolons.
Comment out ellipses.
Use object shorthand.
Delete block padding.
Delete default constructors.

(With [this script's](https://github.com/ryanmcdermott/clean-code-javascript/issues/113) results.)