### PR TITLE
Rename state to zipCode to avoid confusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,16 +102,17 @@ setTimeout(() => {
 **Bad:**
 ```javascript
 const address = 'One Infinite Loop, Cupertino 95014';
-const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+const city
+Regex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
 saveCityState(address.match(cityStateRegex)[1], address.match(cityStateRegex)[2]);
 ```
 
 **Good**:
 ```javascript
 const address = 'One Infinite Loop, Cupertino 95014';
-const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
-const [, city, state] = address.match(cityStateRegex);
-saveCityState(city, state);
+const cityZipCodeRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+const [, city, zipCode] = address.match(cityZipCodeRegex);
+saveCityState(city, zipCode);
 ```
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,7 @@ setTimeout(() => {
 **Bad:**
 ```javascript
 const address = 'One Infinite Loop, Cupertino 95014';
-const city
-Regex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
 saveCityState(address.match(cityStateRegex)[1], address.match(cityStateRegex)[2]);
 ```
 

--- a/README.md
+++ b/README.md
@@ -102,8 +102,8 @@ setTimeout(() => {
 **Bad:**
 ```javascript
 const address = 'One Infinite Loop, Cupertino 95014';
-const cityStateRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
-saveCityState(address.match(cityStateRegex)[1], address.match(cityStateRegex)[2]);
+const cityZipCodeRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
+saveCityZipCode(address.match(cityZipCodeRegex)[1], address.match(cityZipCodeRegex)[2]);
 ```
 
 **Good**:
@@ -111,7 +111,7 @@ saveCityState(address.match(cityStateRegex)[1], address.match(cityStateRegex)[2]
 const address = 'One Infinite Loop, Cupertino 95014';
 const cityZipCodeRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
 const [, city, zipCode] = address.match(cityZipCodeRegex);
-saveCityState(city, zipCode);
+saveCityZipCode(city, zipCode);
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Pretty minor. But destructuring state using the regex was a little bit ambiguous since there is no state in the address (zip code instead).