### PR TITLE
Simplify "Use searchable names" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,9 +80,7 @@ can help identify unnamed constants.
 **Bad:**
 ```javascript
 // What the heck is 86400000 for?
-setTimeout(() => {
-  this.blastOff();
-}, 86400000);
+setTimeout(this.blastOff, 86400000);
 
 ```
 
@@ -91,9 +89,7 @@ setTimeout(() => {
 // Declare them as capitalized `const` globals.
 const MILLISECONDS_IN_A_DAY = 86400000;
 
-setTimeout(() => {
-  this.blastOff();
-}, MILLISECONDS_IN_A_DAY);
+setTimeout(this.blastOff, MILLISECONDS_IN_A_DAY);
 
 ```
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ can help identify unnamed constants.
 **Bad:**
 ```javascript
 // What the heck is 86400000 for?
-setTimeout(this.blastOff, 86400000);
+setTimeout(blastOff, 86400000);
 
 ```
 
@@ -89,7 +89,7 @@ setTimeout(this.blastOff, 86400000);
 // Declare them as capitalized `const` globals.
 const MILLISECONDS_IN_A_DAY = 86400000;
 
-setTimeout(this.blastOff, MILLISECONDS_IN_A_DAY);
+setTimeout(blastOff, MILLISECONDS_IN_A_DAY);
 
 ```
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
There is no need to create an arrow function to execute a function inside of the timeout.