### PR TITLE
make bad and old examples more comparable

### DIFF
--- a/README.md
+++ b/README.md
@@ -564,20 +564,8 @@ would be much better to just use ES2015/ES6 classes and simply extend the `Array
 **Bad:**
 ```javascript
 Array.prototype.diff = function diff(comparisonArray) {
-  const values = [];
-  const hash = {};
-
-  for (const i of comparisonArray) {
-    hash[i] = true;
-  }
-
-  for (const i of this) {
-    if (!hash[i]) {
-      values.push(i);
-    }
-  }
-
-  return values;
+  const hash = new Set(comparisonArray);
+  return this.filter(elem => !hash.has(elem));
 };
 ```
 
@@ -585,7 +573,8 @@ Array.prototype.diff = function diff(comparisonArray) {
 ```javascript
 class SuperArray extends Array {
   diff(comparisonArray) {
-    return this.filter(elem => !comparisonArray.includes(elem));
+    const hash = new Set(comparisonArray);
+    return this.filter(elem => !hash.has(elem));
   }
 }
 ```


### PR DESCRIPTION
See [the comment](https://github.com/ryanmcdermott/clean-code-javascript/pull/65#issuecomment-272082413) of @ryanmcdermott.

With this PR:

1. Bad and old examples become more comparable (let bad examples be bad only in regard to one appropriate case).
2. Both examples do not contain type coercion (i.e. they use strict comparing).
3. The new algorithm has less performance difference in small and large arrays comparing (some benchmarks have been done).