### PR TITLE
fix async/await example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1726,11 +1726,8 @@ require('request-promise').get('https://en.wikipedia.org/wiki/Robert_Cecil_Marti
 ```javascript
 async function getCleanCodeArticle() {
   try {
-    const request = await require('request-promise');
-    const response = await request.get('https://en.wikipedia.org/wiki/Robert_Cecil_Martin');
-    const fileHandle = await require('fs-promise');
-
-    await fileHandle.writeFile('article.html', response);
+    const response = await require('request-promise').get('https://en.wikipedia.org/wiki/Robert_Cecil_Martin');
+    await require('fs-promise').writeFile('article.html', response);
     console.log('File written');
   } catch(err) {
     console.error(err);


### PR DESCRIPTION
Great resource!

Here's a fix for something I noticed in the `async/await` example. There's no need to `await` a call to `require`, and they might sooner be written in single lines to mimic the style used for the previous examples. I might have overlooked something though, if so, let me know!