### PR TITLE
Change literal for a constant

### DIFF
--- a/README.md
+++ b/README.md
@@ -628,9 +628,11 @@ const programmerOutput = [
   }
 ];
 
+const INITIAL_VALUE = 0;
+
 const totalOutput = programmerOutput
   .map((programmer) => programmer.linesOfCode)
-  .reduce((acc, linesOfCode) => acc + linesOfCode, 0);
+  .reduce((acc, linesOfCode) => acc + linesOfCode, INITIAL_VALUE);
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
I didn't know what was the second argument of `reduce` function and I had to look for it.

I think that now it's more clear.