### PR TITLE
Maker function instead of Function constructor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1010,13 +1010,17 @@ console.log(`Employee name: ${employee.getName()}`); // Employee name: undefined
 
 **Good:**
 ```javascript
-const Employee = function (name) {
-  this.getName = function getName() {
-    return name;
-  };
-};
+function makeEmployee(name) {
+    function getName() {
+        return name;
+    }
 
-const employee = new Employee('John Doe');
+    return {
+        getName
+    };
+}
+
+const employee = makeEmployee('John Doe');
 console.log(`Employee name: ${employee.getName()}`); // Employee name: John Doe
 delete employee.name;
 console.log(`Employee name: ${employee.getName()}`); // Employee name: John Doe

--- a/README.md
+++ b/README.md
@@ -1011,13 +1011,11 @@ console.log(`Employee name: ${employee.getName()}`); // Employee name: undefined
 **Good:**
 ```javascript
 function makeEmployee(name) {
-    function getName() {
-        return name;
-    }
-
-    return {
-        getName
-    };
+  return {
+    getName() {
+      return name;
+    },
+  };
 }
 
 const employee = makeEmployee('John Doe');


### PR DESCRIPTION
Function constructors should be avoided. Using the `this` keyword will increase the risk for bugs. An example: if not using the `new` keyword when creating an instance of the Employee object, `this` will be bound to the global object, and not to the Employee instance.

Use a maker function instead, returning an object, using variables existing in the scope of the function (closure).