### PR TITLE
Composition over inheritance suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1676,27 +1676,31 @@ class EmployeeTaxData extends Employee {
 
 **Good:**
 ```javascript
-class EmployeeTaxData {
-  constructor(ssn, salary) {
-    this.ssn = ssn;
-    this.salary = salary;
-  }
-
-  // ...
+function makeTaxData(ssn, salary) {
+    return {
+        ssn,
+        salary
+    };
 }
 
-class Employee {
-  constructor(name, email) {
-    this.name = name;
-    this.email = email;
-  }
+function makeEmployee(name, email) {
+    let taxData = {};
 
-  setTaxData(ssn, salary) {
-    this.taxData = new EmployeeTaxData(ssn, salary);
-  }
-  // ...
-}
-```
+    function setTaxData(ssn, salary) {
+        taxData = makeTaxData();
+    }
+
+    function getTaxData() {
+        return taxData;
+    }
+
+    return {
+        name,
+        email,
+        setTaxData,
+        getTaxData
+    }
+}```
 **[⬆ back to top](#table-of-contents)**
 
 ## **Testing**

--- a/README.md
+++ b/README.md
@@ -1684,7 +1684,7 @@ function makeTaxData(ssn, salary) {
 }
 
 function makeEmployee(name, email) {
-    let obj = {
+    const obj = {
         name,
         email
     };

--- a/README.md
+++ b/README.md
@@ -1685,16 +1685,17 @@ function makeTaxData(ssn, salary) {
 
 function makeEmployee(name, email) {
     let obj = {
-      name,
-      email
+        name,
+        email
     };
 
     obj.setTaxData = function (ssn, salary) {
         obj.taxData = makeTaxData(ssn, salary);
-    }
+    };
 
     return obj;
-}```
+}
+```
 **[⬆ back to top](#table-of-contents)**
 
 ## **Testing**

--- a/README.md
+++ b/README.md
@@ -1684,22 +1684,16 @@ function makeTaxData(ssn, salary) {
 }
 
 function makeEmployee(name, email) {
-    let taxData = {};
-
-    function setTaxData(ssn, salary) {
-        taxData = makeTaxData();
-    }
-
-    function getTaxData() {
-        return taxData;
-    }
-
-    return {
-        name,
-        email,
-        setTaxData,
-        getTaxData
+    let obj = {
+      name,
+      email
     };
+
+    obj.setTaxData = function (ssn, salary) {
+        obj.taxData = makeTaxData(ssn, salary);
+    }
+
+    return obj;
 }```
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1677,23 +1677,23 @@ class EmployeeTaxData extends Employee {
 **Good:**
 ```javascript
 function makeTaxData(ssn, salary) {
-    return {
-        ssn,
-        salary
-    };
+  return {
+    ssn,
+    salary
+  };
 }
 
 function makeEmployee(name, email) {
-    const obj = {
-        name,
-        email
-    };
+  const obj = {
+    name,
+    email
+  };
 
-    obj.setTaxData = function (ssn, salary) {
-        obj.taxData = makeTaxData(ssn, salary);
-    };
+  obj.setTaxData = function (ssn, salary) {
+    obj.taxData = makeTaxData(ssn, salary);
+  };
 
-    return obj;
+  return obj;
 }
 ```
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -1699,7 +1699,7 @@ function makeEmployee(name, email) {
         email,
         setTaxData,
         getTaxData
-    }
+    };
 }```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Functions returning objects instead of classes may simplify composition, syntax and reuse.

Also, by using maker functions, the `this` keyword can be avoided when referencing to varables within the scope (closure).