### PR TITLE
Single Responsibility Principle: modules instead of classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,7 @@ class UserSettings {
 
 **Good:**
 ```javascript
-// this is the module userAuth.js
+// the module userAuth.js
 function verifyCredentials(user) {
     // ...
 }
@@ -1070,8 +1070,8 @@ function verifyCredentials(user) {
 export default verifyCredentials;
 
 
-// this is the module userSettings.js
-import verifyCredentials from 'userAuth';
+// the module userSettings.js
+import verifyCredentials from 'userAuth.js';
 
 function changeSettings(user, settings) {
     if (verifyCredentials(user)) {

--- a/README.md
+++ b/README.md
@@ -1049,12 +1049,12 @@ class UserSettings {
   }
 
   changeSettings(settings) {
-    if (this.verifyCredentials()) {
+    if (this.hasValidCredentials()) {
       // ...
     }
   }
 
-  verifyCredentials() {
+  hasValidCredentials() {
     // ...
   }
 }
@@ -1063,18 +1063,18 @@ class UserSettings {
 **Good:**
 ```javascript
 // the module userAuth.js
-function verifyCredentials(user) {
+function hasValidCredentials(user) {
     // ...
 }
 
-export default verifyCredentials;
+export default hasValidCredentials;
 
 
 // the module userSettings.js
-import verifyCredentials from 'userAuth.js';
+import hasValidCredentials from 'userAuth.js';
 
 function changeSettings(user, settings) {
-    if (verifyCredentials(user)) {
+    if (hasValidCredentials(user)) {
         // ...
     }
 }

--- a/README.md
+++ b/README.md
@@ -1062,29 +1062,24 @@ class UserSettings {
 
 **Good:**
 ```javascript
-class UserAuth {
-  constructor(user) {
-    this.user = user;
-  }
-
-  verifyCredentials() {
+// this is the module userAuth.js
+function verifyCredentials(user) {
     // ...
-  }
 }
 
+export default verifyCredentials;
 
-class UserSettings {
-  constructor(user) {
-    this.user = user;
-    this.auth = new UserAuth(user);
-  }
 
-  changeSettings(settings) {
-    if (this.auth.verifyCredentials()) {
-      // ...
+// this is the module userSettings.js
+import verifyCredentials from 'userAuth';
+
+function changeSettings(user, settings) {
+    if (verifyCredentials(user)) {
+        // ...
     }
-  }
 }
+
+export default changeSettings;
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
I think the SRP pattern can be applied to JavaScript functions and modules, with benefits:
* less code
* no need for state
* testable code

I think the code in this Pull Request has simplified the example code, also removed the duplication of the "user" property (both set in the UserSettings and UserAuth classes in the main branch).

This PR plays well with the "SOLID" PR: https://github.com/ryanmcdermott/clean-code-javascript/pull/178