### PR TITLE
Liskov Substitution (SOLID section) - width/height/length as constructor params

### DIFF
--- a/README.md
+++ b/README.md
@@ -1252,22 +1252,14 @@ class Shape {
   }
 
   render(area) {
-    // ...
+    // ..
   }
 }
 
 class Rectangle extends Shape {
-  constructor() {
+  constructor(width, height) {
     super();
-    this.width = 0;
-    this.height = 0;
-  }
-
-  setWidth(width) {
     this.width = width;
-  }
-
-  setHeight(height) {
     this.height = height;
   }
 
@@ -1277,12 +1269,8 @@ class Rectangle extends Shape {
 }
 
 class Square extends Shape {
-  constructor() {
+  constructor(length) {
     super();
-    this.length = 0;
-  }
-
-  setLength(length) {
     this.length = length;
   }
 
@@ -1293,21 +1281,12 @@ class Square extends Shape {
 
 function renderLargeShapes(shapes) {
   shapes.forEach((shape) => {
-    switch (shape.constructor.name) {
-      case 'Square':
-        shape.setLength(5);
-        break;
-      case 'Rectangle':
-        shape.setWidth(4);
-        shape.setHeight(5);
-    }
+      const area = shape.getArea();
+      shape.render(area);
+    });
+  }
 
-    const area = shape.getArea();
-    shape.render(area);
-  });
-}
-
-const shapes = [new Rectangle(), new Rectangle(), new Square()];
+const shapes = [new Rectangle(4, 5), new Rectangle(4, 5), new Square(5)];
 renderLargeShapes(shapes);
 ```
 **[⬆ back to top](#table-of-contents)**

--- a/README.md
+++ b/README.md
@@ -1252,7 +1252,7 @@ class Shape {
   }
 
   render(area) {
-    // ..
+    // ...
   }
 }
 


### PR DESCRIPTION
The good example of the Liskov Substitution principle in the SOLID section is doing a switch case to set the width/height/length of the shapes. I think they should accept parameters on instantiation. Lot's of code can be deleted: the switch clause and all setters for width/height/length. Less code!