### PR TITLE
Interface Segregation Principle: avoid "fat" interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -1339,32 +1339,28 @@ function postMessage(message) {
   console.log(message);
 }
 
-class Rating {
-  constructor() {
-    this._rating = 0;
-  }
+function makeRating() {
+  let stars = 0;
 
-  get() {
-    return this._rating;
-  }
+  const get = () => stars;
+  const set = (numberOfStars) => stars = numberOfStars;
 
-  set(stars) {
-    this._rating = stars;
-  }
+  return {
+    get,
+    set
+  };
 }
 
-class Feedback {
-  constructor() {
-    this._feedback = [];
-  }
+function makeFeedback() {
+  const messages = [];
 
-  get() {
-    return this._feedback;
-  }
+  const get = () => messages;
+  const add = (message) => messages.push(message);
 
-  add(message) {
-    this._feedback.push(message);
-  }
+  return {
+    get,
+    add
+  };
 }
 ```
 
@@ -1372,7 +1368,7 @@ class Feedback {
 // different "clients", composed with features that makes sense
 class MessageForFeedback {
   constructor() {
-    this._feedback = new Feedback();
+    this._feedback = makeFeedback();
   }
 
   share(message) {
@@ -1386,7 +1382,7 @@ class MessageForFeedback {
 
 class MessageForRating {
   constructor() {
-    this._ratings = new Rating();
+    this._ratings = makeRating();
   }
 
   rate(stars) {

--- a/README.md
+++ b/README.md
@@ -1285,76 +1285,125 @@ renderLargeShapes(shapes);
 **[⬆ back to top](#table-of-contents)**
 
 ### Interface Segregation Principle (ISP)
-JavaScript doesn't have interfaces so this principle doesn't apply as strictly
-as others. However, it's important and relevant even with JavaScript's lack of
-type system.
-
 ISP states that "Clients should not be forced to depend upon interfaces that
-they do not use." Interfaces are implicit contracts in JavaScript because of
-duck typing.
-
-A good example to look at that demonstrates this principle in JavaScript is for
-classes that require large settings objects. Not requiring clients to setup
-huge amounts of options is beneficial, because most of the time they won't need
-all of the settings. Making them optional helps prevent having a "fat interface".
+they do not use." For JavaScript, an "interface" is the contract of an object (the public properties and methods). In the "Bad" example below, the Feedback subclass inherit everything from the Message class, but only a couple of the features makes sense to the sublclass.
 
 **Bad:**
 ```javascript
-class DOMTraverser {
-  constructor(settings) {
-    this.settings = settings;
-    this.setup();
+class Message {
+  constructor() {
+    this._feedback = [];
+    this._rating = 0;
   }
 
-  setup() {
-    this.rootNode = this.settings.rootNode;
-    this.animationModule.setup();
+  addFeedback(message) {
+    this._feedback.push(message);
   }
 
-  traverse() {
-    // ...
+  getFeedback() {
+    return this._feedback;
+  }
+
+  // this method makes no sense to the Feedback subclass
+  getRating() {
+    return this._rating;
+  }
+
+  // this method makes no sense to the Feedback subclass
+  setRating(stars) {
+    this._rating = stars;
+  }
+
+  // this method makes no sense to the Feedback subclass
+  postMessage(message) {
+    console.log(message);
   }
 }
 
-const $ = new DOMTraverser({
-  rootNode: document.getElementsByTagName('body'),
-  animationModule() {} // Most of the time, we won't need to animate when traversing.
-  // ...
-});
+// "clients"
+class MessageForFeedback extends Message {
 
+  share(message) {
+    return super.addFeedback(message);
+  }
+
+  get() {
+    return super.getFeedback();
+  }
+}
 ```
 
 **Good:**
 ```javascript
-class DOMTraverser {
-  constructor(settings) {
-    this.settings = settings;
-    this.options = settings.options;
-    this.setup();
+// "interfaces", separated by feature
+function postMessage(message) {
+  console.log(message);
+}
+
+class Rating {
+  constructor() {
+    this._rating = 0;
   }
 
-  setup() {
-    this.rootNode = this.settings.rootNode;
-    this.setupOptions();
+  get() {
+    return this._rating;
   }
 
-  setupOptions() {
-    if (this.options.animationModule) {
-      // ...
-    }
-  }
-
-  traverse() {
-    // ...
+  set(stars) {
+    this._rating = stars;
   }
 }
 
-const $ = new DOMTraverser({
-  rootNode: document.getElementsByTagName('body'),
-  options: {
-    animationModule() {}
+class Feedback {
+  constructor() {
+    this._feedback = [];
   }
-});
+
+  get() {
+    return this._feedback;
+  }
+
+  add(message) {
+    this._feedback.push(message);
+  }
+}
+// "clients", composed with features that makes sense to the current object
+class MessageForFeedback {
+  constructor() {
+    this._feedback = new Feedback();
+  }
+
+  share(message) {
+    return this._feedback.add(message);
+  }
+
+  get() {
+    return this._feedback.get();
+  }
+}
+
+class MessageForRating {
+  constructor() {
+    this._ratings = new Rating();
+  }
+
+  rate(stars) {
+    return this._ratings.set(stars);
+  }
+
+  send() {
+    postMessage(this._ratings.get());
+  }
+}
+
+// example usage
+const feedback = new MessageForFeedback();
+feedback.share('Good job!');
+const result = feedback.get();
+
+const ratings = new MessageForRating();
+ratings.rate(5);
+ratings.send();
 ```
 **[⬆ back to top](#table-of-contents)**
 

--- a/README.md
+++ b/README.md
@@ -1285,8 +1285,8 @@ renderLargeShapes(shapes);
 **[⬆ back to top](#table-of-contents)**
 
 ### Interface Segregation Principle (ISP)
-ISP states that "Clients should not be forced to depend upon interfaces that
-they do not use." In JavaScript, an interface is the contract of an object (i.e. the public properties and methods). In the "Bad" example below, the Feedback subclass inherits everything from the Message class, but only a couple of the features will
+ISP states that "___Clients should not be forced to depend upon interfaces that
+they do not use.___" In JavaScript, an interface is the contract of an object (i.e. the public properties and methods). In the "Bad" example below, the `Feedback` class inherits everything from the `Message` class, but only a couple of the features will
 make sense to the subclass.
 
 **Bad:**

--- a/README.md
+++ b/README.md
@@ -1286,7 +1286,8 @@ renderLargeShapes(shapes);
 
 ### Interface Segregation Principle (ISP)
 ISP states that "Clients should not be forced to depend upon interfaces that
-they do not use." For JavaScript, an "interface" is the contract of an object (the public properties and methods). In the "Bad" example below, the Feedback subclass inherit everything from the Message class, but only a couple of the features makes sense to the sublclass.
+they do not use." In JavaScript, an interface is the contract of an object (i.e. the public properties and methods). In the "Bad" example below, the Feedback subclass inherits everything from the Message class, but only a couple of the features will
+make sense to the subclass.
 
 **Bad:**
 ```javascript
@@ -1320,9 +1321,7 @@ class Message {
   }
 }
 
-// "clients"
 class MessageForFeedback extends Message {
-
   share(message) {
     return super.addFeedback(message);
   }
@@ -1335,7 +1334,7 @@ class MessageForFeedback extends Message {
 
 **Good:**
 ```javascript
-// "interfaces", separated by feature
+// several "interfaces", separated by feature
 function postMessage(message) {
   console.log(message);
 }
@@ -1367,7 +1366,10 @@ class Feedback {
     this._feedback.push(message);
   }
 }
-// "clients", composed with features that makes sense to the current object
+```
+
+```javascript
+// different "clients", composed with features that makes sense
 class MessageForFeedback {
   constructor() {
     this._feedback = new Feedback();


### PR DESCRIPTION
I have tried to learn more about ISP, and think the main idea is about avoiding "fat" interfaces when composing objects. I don't think the DOMParser example shows that. Let me know if I am misunderstanding the current DOMParser example, or have got the ideas of the Interface Segregation Principle wrong. I would very much appreciate it!

For this Repo, I have coded the examples using classes, because the other SOLID examples use that style of coding.


Note:
I prefer a more straight forward functions approach and have tried to accomplish that in this example (in my "func remix" fork): https://github.com/DavidVujic/clean-code-javascript/blob/master/examples/interface-segregation-principle-GOOD.js