### PR TITLE
fixed a mismatch between bad-good example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1995,7 +1995,7 @@ class PerformanceReview {
   }
 }
 
-const review = new PerformanceReview(user);
+const review = new PerformanceReview(employee);
 review.perfReview();
 ```
 


### PR DESCRIPTION
Fixed a mismatch between bad & good example that cause a distraction. That's in `Function callers and callees should be close` section.