### PR TITLE
Change argument name of "Use default arguments instead of short circu…

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ function createMicrobrewery(name) {
 
 **Good:**
 ```javascript
-function createMicrobrewery(breweryName = 'Hipster Brew Co.') {
+function createMicrobrewery(name = 'Hipster Brew Co.') {
   // ...
 }
 


### PR DESCRIPTION
…iting or conditionals".

Did not adhere to "Don't add unneeded context".