### PR TITLE
Changing order in example of *Functions should only be one level …*

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ saveCityZipCode(city, zipCode);
 ```
 **[⬆ back to top](#table-of-contents)**
 
-### Avoid Mental Mappingf
+### Avoid Mental Mapping
 Explicit is better than implicit.
 
 **Bad:**

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ saveCityZipCode(city, zipCode);
 ```
 **[⬆ back to top](#table-of-contents)**
 
-### Avoid Mental Mapping
+### Avoid Mental Mappingf
 Explicit is better than implicit.
 
 **Bad:**
@@ -343,6 +343,14 @@ function parseBetterJSAlternative(code) {
 
 **Good:**
 ```javascript
+function parseBetterJSAlternative(code) {
+  const tokens = tokenize(code);
+  const ast = lexer(tokens);
+  ast.forEach((node) => {
+    // parse...
+  });
+}
+
 function tokenize(code) {
   const REGEXES = [
     // ...
@@ -366,14 +374,6 @@ function lexer(tokens) {
   });
 
   return ast;
-}
-
-function parseBetterJSAlternative(code) {
-  const tokens = tokenize(code);
-  const ast = lexer(tokens);
-  ast.forEach((node) => {
-    // parse...
-  });
 }
 ```
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
Like said in https://github.com/ryanmcdermott/clean-code-javascript#function-callers-and-callees-should-be-close, the code is read from top to bottom, so I'd prefer the definition of the *function parseBetterJSAlternative* above the functions called within.
