### PR TITLE
improve "Functions should only be one level of abstraction" example

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,8 +345,8 @@ function parseBetterJSAlternative(code) {
 ```javascript
 function parseBetterJSAlternative(code) {
   const tokens = tokenize(code);
-  const ast = lexer(tokens);
-  ast.forEach((node) => {
+  const syntaxTree = parse(tokens);
+  syntaxTree.forEach((node) => {
     // parse...
   });
 }
@@ -367,13 +367,13 @@ function tokenize(code) {
   return tokens;
 }
 
-function lexer(tokens) {
-  const ast = [];
+function parse(tokens) {
+  const syntaxTree = [];
   tokens.forEach((token) => {
-    ast.push( /* ... */ );
+    syntaxTree.push( /* ... */ );
   });
 
-  return ast;
+  return syntaxTree;
 }
 ```
 **[⬆ back to top](#table-of-contents)**


### PR DESCRIPTION
Enjoyed reading this article! Some slight suggestions: 

- rename ast variable to be more explicit (see, Avoid Mental Mapping)
- rename function lexer to include a verb in it's name (see,
  https://herbertograca.com/2016/09/03/clean-code-3-functions-by-robert-c-martin-uncle-bob/)
- from my understanding, the term lexer is usally used for the
  process of building a stream of tokens. So lexer and tokenize are
  different names for the same thing