### PR TITLE
remove map method in favor functional programming

### DIFF
--- a/README.md
+++ b/README.md
@@ -706,8 +706,7 @@ const programmerOutput = [
 ];
 
 const totalOutput = programmerOutput
-  .map(output => output.linesOfCode)
-  .reduce((totalLines, lines) => totalLines + lines);
+  .reduce((totalLines, output) => totalLines + output.linesOfCode, 0)
 ```
 **[⬆ back to top](#table-of-contents)**
 


### PR DESCRIPTION
Unnecessary Array.prototype.map method.