### PR TITLE
fixbug: judge existence before use in "Use explanatory variables"

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ setTimeout(blastOff, MILLISECONDS_IN_A_DAY);
 ```javascript
 const address = "One Infinite Loop, Cupertino 95014";
 const cityZipCodeRegex = /^[^,\\]+[,\\\s]+(.+?)\s*(\d{5})?$/;
-saveCityZipCode(
+address.match(cityZipCodeRegex) && saveCityZipCode(
   address.match(cityZipCodeRegex)[1],
   address.match(cityZipCodeRegex)[2]
 );


### PR DESCRIPTION
saveCityZipCode(
  address.match(cityZipCodeRegex)[1],
  address.match(cityZipCodeRegex)[2]
);
This is not just bad, and may be error. It is necessay to judge existence before use. Because we are compare good code with bad code, not error code.