### PR TITLE
Added numeric separator for improve readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ setTimeout(blastOff, 86400000);
 
 ```javascript
 // Declare them as capitalized named constants.
-const MILLISECONDS_IN_A_DAY = 86400000;
+const MILLISECONDS_IN_A_DAY = 86_400_000;
 
 setTimeout(blastOff, MILLISECONDS_IN_A_DAY);
 ```


### PR DESCRIPTION
`const MILLISECONDS_IN_A_DAY = 86_400_000;`

We can use numeric separator with 
https://babeljs.io/docs/en/babel-plugin-proposal-numeric-separator