### PR TITLE
Focus on cleaner example for `Favor functional programming over imperative programming`

### DIFF
--- a/README.md
+++ b/README.md
@@ -737,8 +737,6 @@ JavaScript isn't a functional language in the way that Haskell is, but it has
 a functional flavor to it. Functional languages can be cleaner and easier to test.
 Favor this style of programming when you can.
 
-**Bad:**
-
 ```javascript
 const programmerOutput = [
   {
@@ -758,7 +756,11 @@ const programmerOutput = [
     linesOfCode: 1000
   }
 ];
+```
 
+**Bad:**
+
+```javascript
 let totalOutput = 0;
 
 for (let i = 0; i < programmerOutput.length; i++) {
@@ -769,25 +771,6 @@ for (let i = 0; i < programmerOutput.length; i++) {
 **Good:**
 
 ```javascript
-const programmerOutput = [
-  {
-    name: "Uncle Bobby",
-    linesOfCode: 500
-  },
-  {
-    name: "Suzie Q",
-    linesOfCode: 1500
-  },
-  {
-    name: "Jimmy Gosling",
-    linesOfCode: 150
-  },
-  {
-    name: "Gracie Hopper",
-    linesOfCode: 1000
-  }
-];
-
 const totalOutput = programmerOutput.reduce(
   (totalLines, output) => totalLines + output.linesOfCode,
   0


### PR DESCRIPTION
making `Favor functional programming over imperative programming` example more cleaner to understand and focus by separating the data and examples.

![image](https://user-images.githubusercontent.com/59599950/115947608-12339f00-a4de-11eb-99af-3a34de8ce66a.png)
