### PR TITLE
Improve example code demonstrating Interface Segregation Principle.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1718,9 +1718,8 @@ class DOMTraverser {
 
 const $ = new DOMTraverser({
   rootNode: document.getElementsByTagName("body"),
-  options: {
-    animationModule() {}
-  }
+  options: {}  // Note how this part of the code doesn't even
+               // need to know that animationModule even exists.
 });
 ```
 


### PR DESCRIPTION
Hello.  This is a useful resource.

When reading the section on the Interface Segregation Principle it occurred to me that the code section could give a stronger and clearer example.  The principle is "Clients should not be forced to depend upon interfaces that they do not use."  Even knowing about the existence is a dependency, and it can be avoided in this case.  There is no reason for the client code to even know that animationModule exists or that DOMTraverser cares about it.

(This sort of thing happens frequently in practice; e.g. if animationModule is added to a new version of DOMTraverser, old client code will not know about it, and making it optional in this way avoids having to update those calls.)