### PR TITLE
docs: fix broken link in formatting section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2083,12 +2083,11 @@ getdata()
 
 Formatting is subjective. Like many rules herein, there is no hard and fast
 rule that you must follow. The main point is DO NOT ARGUE over formatting.
-There are [tons of tools](https://standardjs.com/rules.html) to automate this.
+There are [tons of tools](https://standardjs.com) to automate this.
 Use one! It's a waste of time and money for engineers to argue over formatting.
 
 For things that don't fall under the purview of automatic formatting
-(indentation, tabs vs. spaces, double vs. single quotes, etc.) look here
-for some guidance.
+(indentation, tabs vs. spaces, double vs. single quotes, etc.) look [here](ttps://standardjs.com/rules.html) for some guidance.
 
 ### Use consistent capitalization
 


### PR DESCRIPTION
Closes #387