### PR TITLE
fix:  ReferenceError email is not defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -312,7 +312,7 @@ function emailClients(clients) {
 
 ```javascript
 function emailActiveClients(clients) {
-  clients.filter(isActiveClient).forEach(email);
+  clients.filter(isActiveClient).forEach(email => email);
 }
 
 function isActiveClient(client) {


### PR DESCRIPTION
Your Example : 
```javascript
function emailActiveClients(clients) {
  clients.filter(isActiveClient).forEach(email);
}
```
Error: ReferenceError email is not defined

I fix example
```javascript
function emailActiveClients(clients) {
  clients.filter(isActiveClient).forEach(email => email);
}
```