### PR TITLE
Fix: Correct camelCase for getdata() to getData() in Error Handling section

### DIFF
--- a/README.md
+++ b/README.md
@@ -2050,7 +2050,7 @@ from `try/catch`.
 **Bad:**
 
 ```javascript
-getdata()
+getData()
   .then(data => {
     functionThatMightThrow(data);
   })
@@ -2062,7 +2062,7 @@ getdata()
 **Good:**
 
 ```javascript
-getdata()
+getData()
   .then(data => {
     functionThatMightThrow(data);
   })


### PR DESCRIPTION
Fixed incorrect camelCase in the Error Handling section.
"getdata()" corrected to "getData()" in both the Bad and Good
examples under "Don't ignore rejected promises".
This is especially ironic in a clean-code guide!